### PR TITLE
[WIP] Login and roles/permissions

### DIFF
--- a/app/models/user.go
+++ b/app/models/user.go
@@ -4,12 +4,18 @@ import "github.com/jinzhu/gorm"
 
 type User struct {
 	gorm.Model
-	Email     string
-	Password  string
-	Name      string
-	Gender    string
-	Role      string
-	Addresses []Address
+	Email string `gorm:"not null;unique_index"` // TODO/problem: can't reuse emails
+
+	Hashed []byte
+
+	// only used for input validation and renewal
+	Current  string `gorm:"-"`
+	Password string `gorm:"-"`
+	Repeat   string `gorm:"-"`
+
+	Role   string
+	Name   string
+	Gender string
 }
 
 func (user User) DisplayName() string {

--- a/config/admin/admin.go
+++ b/config/admin/admin.go
@@ -22,12 +22,20 @@ import (
 )
 
 var Admin *admin.Admin
+
+// QorAuth exposes the Auth instance only for the Handler helper in main to check authentication...
+var QorAuth Auth
+
 var Countries = []string{"China", "Japan", "USA"}
 
 func init() {
+	if err := QorAuth.Init(); err != nil {
+		panic(err)
+	}
+
 	Admin = admin.New(&qor.Config{DB: db.Publish.DraftDB()})
 	Admin.SetSiteName("Qor DEMO")
-	Admin.SetAuth(Auth{})
+	Admin.SetAuth(&QorAuth)
 
 	// Add Dashboard
 	Admin.AddMenu(&admin.Menu{Name: "Dashboard", Link: "/admin"})

--- a/config/admin/admin.go
+++ b/config/admin/admin.go
@@ -39,7 +39,7 @@ func init() {
 	Admin.SetAuth(&QorAuth)
 
 	// Add Dashboard
-	Admin.AddMenu(&admin.Menu{Name: "Dashboard", Link: "/admin"})
+	Admin.AddMenu(&admin.Menu{Name: "Dashboard", Link: "/admin/qor"})
 
 	// Add Asset Manager, for rich editor
 	assetManager := Admin.AddResource(&media_library.AssetManager{}, &admin.Config{Invisible: true})

--- a/config/admin/auth.go
+++ b/config/admin/auth.go
@@ -1,21 +1,100 @@
 package admin
 
 import (
-	"github.com/qor/qor"
-	"github.com/qor/qor-example/app/models"
+	"fmt"
+	"log"
+
+	"github.com/cryptix/go/http/auth"
+	"github.com/gorilla/securecookie"
+	"github.com/gorilla/sessions"
 	"github.com/qor/admin"
+	"github.com/qor/qor"
+	"golang.org/x/crypto/bcrypt"
+
+	"github.com/qor/qor-example/app/models"
+	"github.com/qor/qor-example/db"
 )
 
-type Auth struct{}
+const (
+	sessionName = "qor_admin"
+	authLanding = "/admin/qor"
+	authLogout  = "/admin_login"
+)
 
-func (Auth) LoginURL(c *admin.Context) string {
-	return "/admin"
+type Auth struct {
+	store   sessions.Store
+	Handler *auth.Handler
 }
 
-func (Auth) LogoutURL(c *admin.Context) string {
-	return "/admin"
+func (a *Auth) Init() error {
+	a.store = &sessions.CookieStore{
+		Codecs: securecookie.CodecsFromPairs(
+			[]byte("verysecretverysecretverysecret!!"), // TODO: gen and persist or panic
+			[]byte("verysecretverysecretverysecret@@"),
+		),
+		Options: &sessions.Options{
+			Path:     "/", // TODO check what this means
+			MaxAge:   3600 * 24 * 30,
+			HttpOnly: true,
+		},
+	}
+	var err error
+	a.Handler, err = auth.NewHandler(a,
+		auth.SetStore(a.store),
+		auth.SetSessionName(sessionName),
+		auth.SetLanding(authLanding),
+		auth.SetLogout(authLogout),
+	)
+
+	return err
 }
 
-func (Auth) GetCurrentUser(c *admin.Context) qor.CurrentUser {
-	return &models.User{Name: "Admin"}
+// used by AuthenticateRequest
+// TODO: should i trust GetCurrentUser() == nil for auth?
+func (a *Auth) Check(name, pw string) (interface{}, error) {
+	var u models.User
+	err := db.DB.Where(&models.User{Email: name}).First(&u).Error
+	if err != nil {
+		log.Print("Login failed.", map[string]interface{}{
+			"user": name,
+			"err":  err,
+		})
+		return nil, auth.ErrBadLogin
+	}
+	err = bcrypt.CompareHashAndPassword(u.Hashed, []byte(pw))
+	if err != nil {
+		return nil, auth.ErrBadLogin
+	}
+	return u.ID, nil
+}
+
+func (Auth) LoginURL(c *admin.Context) string  { return "/admin_login" }
+func (Auth) LogoutURL(c *admin.Context) string { return authLogout }
+
+func (a *Auth) GetCurrentUser(c *admin.Context) qor.CurrentUser {
+	data, err := a.Handler.AuthenticateRequest(c.Context.Request)
+	if err != nil {
+		log.Print("qor/auth/GetCurrentUser: Authentication failed:", err)
+		return nil
+	}
+
+	id, ok := data.(uint)
+	if !ok {
+		log.Print("qor/auth/GetCurrentUser: casting session failed.", map[string]interface{}{
+			"data": data,
+			"type": fmt.Sprintf("%t", data),
+		})
+		return nil
+	}
+	var u models.User
+	u.ID = id
+	err = db.DB.Where(u).First(&u).Error
+	if err != nil {
+		log.Print("qor/auth/GetCurrentUser: db lookup by ID failed", map[string]interface{}{
+			"user": id,
+			"err":  err,
+		})
+		return nil
+	}
+	return &u
 }

--- a/config/admin/auth.go
+++ b/config/admin/auth.go
@@ -16,9 +16,9 @@ import (
 )
 
 const (
-	sessionName = "qor_admin"
-	authLanding = "/admin/qor"
-	authLogout  = "/admin_login"
+	sessionName = "qor_example"
+	authLanding = "/admin" // redirect location after login
+	authLogout  = "/login" // redirect location after logout
 )
 
 type Auth struct {
@@ -68,7 +68,7 @@ func (a *Auth) Check(name, pw string) (interface{}, error) {
 	return u.ID, nil
 }
 
-func (Auth) LoginURL(c *admin.Context) string  { return "/admin_login" }
+func (Auth) LoginURL(c *admin.Context) string  { return "/login" }
 func (Auth) LogoutURL(c *admin.Context) string { return authLogout }
 
 func (a *Auth) GetCurrentUser(c *admin.Context) qor.CurrentUser {

--- a/config/config.go
+++ b/config/config.go
@@ -24,7 +24,7 @@ var (
 )
 
 func init() {
-	cfgPath := os.Getenv("QOR_DBPATH")
+	cfgPath := os.Getenv("QOR_CONFIGFILE")
 	if cfgPath == "" {
 		cfgPath = "config/database.yml"
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -12,6 +12,7 @@ var Config = struct {
 	DB   struct {
 		Name     string `default:"qor_example"`
 		Adapter  string `default:"mysql"`
+		Host     string `default:"localhost"`
 		User     string
 		Password string
 	}
@@ -23,7 +24,12 @@ var (
 )
 
 func init() {
-	if err := configor.Load(&Config, "config/database.yml"); err != nil {
+	cfgPath := os.Getenv("QOR_DBPATH")
+	if cfgPath == "" {
+		cfgPath = "config/database.yml"
+	}
+
+	if err := configor.Load(&Config, cfgPath); err != nil {
 		panic(err)
 	}
 

--- a/customperms/permOne.go
+++ b/customperms/permOne.go
@@ -1,0 +1,32 @@
+package customperms
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/qor/roles"
+)
+
+type PermTest struct{}
+
+//
+func (p *PermTest) Allow(mode roles.PermissionMode, roles ...string) roles.Permission {
+	panic(fmt.Sprintf("permTest: Allow(%s,%v)", mode, roles))
+}
+
+func (p *PermTest) Concat(roles.Permission) roles.Permission {
+	panic("PermTest: Concat()")
+}
+
+func (p *PermTest) Deny(mode roles.PermissionMode, roles ...string) roles.Permission {
+	panic(fmt.Sprintf("permTest: Deny(%s,%v)", mode, roles))
+}
+
+func (p *PermTest) HasPermission(mode roles.PermissionMode, roles ...string) bool {
+	log.Printf("DBG: permTest: HasPermission(%v, %v)", mode, roles)
+	return true
+}
+
+func (p *PermTest) Role() roles.Role {
+	panic("permTest: Role()")
+}

--- a/db/db.go
+++ b/db/db.go
@@ -27,7 +27,7 @@ func init() {
 	if config.Config.DB.Adapter == "mysql" {
 		DB, err = gorm.Open("mysql", fmt.Sprintf("%v:%v@/%v?parseTime=True&loc=Local", dbConfig.User, dbConfig.Password, dbConfig.Name))
 	} else if config.Config.DB.Adapter == "postgres" {
-		DB, err = gorm.Open("postgres", fmt.Sprintf("user=%v password=%v dbname=%v sslmode=disable", dbConfig.User, dbConfig.Password, dbConfig.Name))
+		DB, err = gorm.Open("postgres", fmt.Sprintf("postgres://%s:%s@%s/%s?sslmode=disable", dbConfig.User, dbConfig.Password, dbConfig.Host, dbConfig.Name))
 	} else {
 		panic(errors.New("not supported database adapter"))
 	}

--- a/helper/exAddUser.go
+++ b/helper/exAddUser.go
@@ -1,0 +1,48 @@
+// +build ignore
+
+package main
+
+import (
+	"flag"
+	"log"
+	"os"
+
+	_ "github.com/lib/pq"
+	"golang.org/x/crypto/bcrypt"
+
+	"github.com/qor/qor-example/app/models"
+	"github.com/qor/qor-example/db"
+)
+
+var (
+	email      = flag.String("email", "", "email/login of the user")
+	name       = flag.String("name", "", "name of the user")
+	clearPassw = flag.String("pass", "", "password for the new user")
+	role       = flag.String("role", "default", "the role the user should have")
+	cost       = flag.Int("bcryptCost", bcrypt.MinCost, "cost factor for bcrypt")
+)
+
+func main() {
+	flag.Parse()
+
+	if *email == "" || *clearPassw == "" {
+		log.Println("email and password can't be empty.")
+		log.Fatalf("Usage: %s -email my@login.net -pass musterMaster -role admin", os.Args[0])
+	}
+
+	var u models.User
+	u.Email = *email
+	u.Name = *name
+    u.Role = *role
+	var err error
+	u.Hashed, err = bcrypt.GenerateFromPassword([]byte(*clearPassw), *cost)
+	check(err)
+	check(db.DB.Save(&u).Error)
+	log.Println("User Added")
+}
+
+func check(err error) {
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -3,6 +3,8 @@ package main
 import (
 	"fmt"
 	"net/http"
+	"os"
+	"strconv"
 
 	"github.com/qor/qor-example/config"
 	"github.com/qor/qor-example/config/admin"
@@ -16,13 +18,8 @@ func main() {
 	mux := http.NewServeMux()
 	mux.Handle("/", routes.Router())
 
-	// subrouter - protected by admin.QorAuth.Handler.Authenticate
-	adminMux := http.NewServeMux()
-
-	admin.Admin.MountTo("/admin/qor", adminMux)
-
 	// todo: move this to frontend templating
-	mux.Handle("/admin_login", http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+	mux.Handle("/login", http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 		if r.Method == "POST" {
 			admin.QorAuth.Handler.Authorize(rw, r)
 		} else {
@@ -39,9 +36,9 @@ func main() {
 </html>`)
 		}
 	}))
-	mux.Handle("/admin_logout", http.HandlerFunc(admin.QorAuth.Handler.Logout))
+	mux.Handle("/logout", http.HandlerFunc(admin.QorAuth.Handler.Logout))
 
-	mux.Handle("/admin/", admin.QorAuth.Handler.Authenticate(adminMux))
+	admin.Admin.MountTo("/admin", mux)
 	api.API.MountTo("/api", mux)
 
 	for _, path := range []string{"system", "downloads", "javascripts", "stylesheets", "images"} {

--- a/main.go
+++ b/main.go
@@ -15,7 +15,33 @@ import (
 func main() {
 	mux := http.NewServeMux()
 	mux.Handle("/", routes.Router())
-	admin.Admin.MountTo("/admin", mux)
+
+	// subrouter - protected by admin.QorAuth.Handler.Authenticate
+	adminMux := http.NewServeMux()
+
+	admin.Admin.MountTo("/admin/qor", adminMux)
+
+	// todo: move this to frontend templating
+	mux.Handle("/admin_login", http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		if r.Method == "POST" {
+			admin.QorAuth.Handler.Authorize(rw, r)
+		} else {
+			fmt.Fprintf(rw, `
+<html>
+    <body>
+    <h1>Login</h1>
+    <form method="POST">
+        <input type="text" name="user">
+        <input type="password" name="pass">
+        <input type="submit">
+    </form>
+    </body>
+</html>`)
+		}
+	}))
+	mux.Handle("/admin_logout", http.HandlerFunc(admin.QorAuth.Handler.Logout))
+
+	mux.Handle("/admin/", admin.QorAuth.Handler.Authenticate(adminMux))
 	api.API.MountTo("/api", mux)
 
 	for _, path := range []string{"system", "downloads", "javascripts", "stylesheets", "images"} {


### PR DESCRIPTION
Hi,

I asked on [gitter](https://gitter.im/qor/qor?at=56fd84ffe4a8384a1bbdbf4b) about a way for more fine-grained/abstract way to to check and grant permissions.

What I have in mind are cases like this which are hard to manage with the current role concept.

* A user owns (meaning created) a row/object and is the only one allowed to view and alter it.
Think password changes, items in a shopping cart or shipping addresses.

* A user belongs to to a certain group
Think something like _only employees of company X are allowed to alter products produced by company X_. Where _employees of company X_ could be checked by a database relation lookup and adding roles for each company isn't feasible.

* A user needs to full-fill some kind of rule
Like a certain amount of internal credit balance or time of day for instance.

I started this branch in pursuit of the first idea, allowing users into `/admin` to manage their user data. For this I added a authentication library based on gorilla/session to differentiate users based on cookies (could be any, just picked it because I wrote it myself).

The next step was converting `roles.Permission` and `roles.Role` into interfaces to see if this is enough to plug in permissions that grant/deny based on other criteria. (I created a fork of [qor/roles](https://github.com/qor/roles/compare/master...cryptix:loginAndRoles) to share this conversion and posted the patches against the other repos [as a gist](https://gist.github.com/cryptix/26eb963530e2b7a20f4ac35aa421c703) to reduce forks for now.)

What I found is that the concept of string based roles is tied in to deeply in the current interface to be more widely usable.
The HTTP request is only available to the role system to decide whether a user belongs to a certain role but the permission checks happen later and are only checking if a role should be allowed to execute a certain action.

I have no solution proposal at this time and would like to discuss approaches that help the qor Community at large before digging deeper into this. I currently wonder if we could synthesize the `Role` and `Permission` interface into a single one  that is dynamic enough to establish other concepts, like the ones I outlined above. They already share 2 methods (Allow and Deny) and the other ones are just there to work with the parts of the qor code base that use the roles package.

Thanks,
Henry