### PR TITLE
correct the requirements to have at least golang version 1.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Chat Room: [![Join the chat at https://gitter.im/qor/qor](https://badges.gitter.
 
 ## Quick Started
 
-### Go version: 1.6+
+### Go version: 1.8+
 
 ```shell
 # Get example app


### PR DESCRIPTION
The documention is not updated on the requirements to use at least golang version 1.8

If you are using lower than version 1.8, certain functions are not available for golang below 1.8

example, running go get on golang 1.7.3 will yield this error:

```
# github.com/qor/admin
../go/src/github.com/qor/admin/route.go:92: undefined: sort.SliceStable
```
This is to update and correct the documentation on the requirement