### PR TITLE
Sometimes the localize action cannot get the right resource

### DIFF
--- a/app/models/blog.go
+++ b/app/models/blog.go
@@ -14,4 +14,7 @@ type Article struct {
 	publish2.Version
 	publish2.Schedule
 	publish2.Visible
+
+	StoreID uint
+	Store   Store
 }

--- a/app/models/store.go
+++ b/app/models/store.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 
 	"github.com/jinzhu/gorm"
+	"github.com/qor/l10n"
 	"github.com/qor/location"
 	"github.com/qor/sorting"
 )
@@ -18,6 +19,7 @@ type Store struct {
 	Email     string
 	location.Location
 	sorting.Sorting
+	l10n.LocaleCreatable
 }
 
 type Owner struct {

--- a/config/admin/admin.go
+++ b/config/admin/admin.go
@@ -42,6 +42,11 @@ var Admin *admin.Admin
 var ActionBar *action_bar.ActionBar
 var Genders = []string{"Men", "Women", "Kids"}
 
+type FromToArgument struct {
+	From string
+	To   []string
+}
+
 func init() {
 	Admin = admin.New(&qor.Config{DB: db.DB.Set(publish2.VisibleMode, publish2.ModeOff).Set(publish2.ScheduleMode, publish2.ModeOff)})
 	Admin.SetSiteName("Qor DEMO")
@@ -494,8 +499,50 @@ func init() {
 	)
 	user.EditAttrs(user.ShowAttrs())
 
+	argumentResource := Admin.NewResource(&FromToArgument{})
+	argumentResource.Meta(&admin.Meta{
+		Name: "From",
+		Type: "select_one",
+		Valuer: func(_ interface{}, context *qor.Context) interface{} {
+			locale, _ := context.GetDB().Get("l10n:locale")
+			return locale.(string)
+		},
+		Collection: func(value interface{}, context *qor.Context) (results [][]string) {
+			names := []string{"United States", "United Kingdom"}
+			for _, name := range names {
+				results = append(results, []string{name, name})
+			}
+			return
+		},
+	})
+	argumentResource.Meta(&admin.Meta{
+		Name: "To",
+		Type: "select_many",
+		Valuer: func(_ interface{}, context *qor.Context) interface{} {
+			return []string{""}
+		},
+		Collection: func(value interface{}, context *qor.Context) (results [][]string) {
+			// ..........
+			return
+		},
+	})
+
+	// Blog Management
+	article := Admin.AddResource(&models.Article{}, &admin.Config{Menu: []string{"Blog Management"}})
+	article.IndexAttrs("ID", "VersionName", "ScheduledStartAt", "ScheduledEndAt", "Author", "Title")
+	// article.Meta(&admin.Meta{
+	// 	Name: "Store",
+	// 	Config: &admin.SelectOneConfig{
+	// 		Collection: func(value interface{}, context *qor.Context) (results [][]string) {
+	// 			// ..........
+	// 			return
+	// 		},
+	// 	},
+	// })
+
 	// Add Store
 	store := Admin.AddResource(&models.Store{}, &admin.Config{Menu: []string{"Store Management"}})
+	store.IndexAttrs("ID", "StoreName")
 	store.Meta(&admin.Meta{Name: "Owner", Type: "single_edit"})
 	store.AddValidator(func(record interface{}, metaValues *resource.MetaValues, context *qor.Context) error {
 		if meta := metaValues.Get("Name"); meta != nil {
@@ -505,10 +552,14 @@ func init() {
 		}
 		return nil
 	})
-
-	// Blog Management
-	article := Admin.AddResource(&models.Article{}, &admin.Config{Menu: []string{"Blog Management"}})
-	article.IndexAttrs("ID", "VersionName", "ScheduledStartAt", "ScheduledEndAt", "Author", "Title")
+	store.Action(&admin.Action{
+		Name: "Localize",
+		Handler: func(argument *admin.ActionArgument) error {
+			// ..........
+			return nil
+		},
+		Resource: argumentResource,
+	})
 
 	// Add Translations
 	Admin.AddResource(i18n.I18n, &admin.Config{Menu: []string{"Site Management"}, Priority: 1})

--- a/db/db.go
+++ b/db/db.go
@@ -36,10 +36,10 @@ func init() {
 		panic(errors.New("not supported database adapter"))
 	}
 
+	DB = DB.Set("gorm:table_options", "CHARSET=utf8")
+
 	if err == nil {
-		if os.Getenv("DEBUG") != "" {
-			DB.LogMode(true)
-		}
+		DB.LogMode(true)
 
 		l10n.RegisterCallbacks(DB)
 		sorting.RegisterCallbacks(DB)


### PR DESCRIPTION
Now the resource for store's localize action should look like this:
![image](https://user-images.githubusercontent.com/506137/31535978-a6b01290-afc2-11e7-858d-921e066c2c98.png)

---

But if we uncomment these lines: https://github.com/qor/qor-example/blob/action-error/config/admin/admin.go#L533-L541, we can see it will look like this (the original one):
![image](https://user-images.githubusercontent.com/506137/31536078-01c1af04-afc3-11e7-8bb5-1141c52dd9c8.png)

---

If we edit the code like this, it will also work:
```
        ......
	store := Admin.AddResource(&models.Store{}, &admin.Config{Menu: []string{"Store Management"}})

	article.Meta(&admin.Meta{
		Name: "Store",
		Config: &admin.SelectOneConfig{
			Collection: func(value interface{}, context *qor.Context) (results [][]string) {
				// ..........
				return
			},
		},
	})
       ......
```
