### PR TITLE
disable S3 microsite feature

### DIFF
--- a/app/enterprise/microsite.go
+++ b/app/enterprise/microsite.go
@@ -10,6 +10,7 @@ import (
 	"github.com/qor/l10n"
 	"github.com/qor/publish2"
 	adminapp "github.com/qor/qor-example/app/admin"
+	"github.com/qor/roles"
 )
 
 var MicroSite *microsite.MicroSite
@@ -46,4 +47,5 @@ func SetupMicrosite(Admin *admin.Admin) {
 	MicroSite.Resource.SetPrimaryFields("ID", "VersionName")
 
 	Admin.AddResource(MicroSite, &admin.Config{Menu: []string{"Pages Management"}, Priority: 2})
+	MicroSite.Resource.GetAction("VIEW S3 DEV SITE").Permission = roles.Deny("*", "*")
 }

--- a/app/views/qor/metas/form/microsite_template_package.tmpl
+++ b/app/views/qor/metas/form/microsite_template_package.tmpl
@@ -1,0 +1,74 @@
+{{$package := (raw_value_of .ResourceValue .Meta)}}
+{{$microSite := .ResourceValue}}
+{{$context := .Context}}
+{{$baseResource := .BaseResource}}
+
+<div class="qor-field qor-microsite qor-microsite-filelist">
+  <div class="qor-microsite--label clearfix">
+    <label class="qor-field__label">
+      {{meta_label .Meta}}
+    </label>
+  </div>
+
+  <div class="qor-field__block qor-file qor-microsite--develop-container"></div>
+
+  <div class="qor-field__block qor-file qor-microsite--package-container">
+
+    {{$actions := $package.ListActions}}
+      {{if $actions}}
+        <div class="qor-microsite-table">
+        <table class="mdl-data-table mdl-js-data-table qor-table qor-table__microsite-package">
+          <thead>
+            <tr>
+              <th class="mdl-data-table__cell--non-numeric">{{t (printf "%v.packages.url" $baseResource.ToParam) "URL"}}</th>
+              <th class="mdl-data-table__cell--non-numeric">{{t (printf "%v.packages.description" $baseResource.ToParam) "Description"}}</th>
+              <th class="mdl-data-table__cell--non-numeric" with="120px"></th>
+            </tr>
+          </thead>
+
+          <tbody>
+            {{range $action := $actions }}
+              {{$type := $action.Type}}
+              <tr data-action-type="{{$type}}">
+                <td class='mdl-data-table__cell--non-numeric path' title="{{$action.Path}}"><p>{{$action.Path}}</p></td>
+
+                {{if (eq $type "redirect")}}
+                  <td class='mdl-data-table__cell--non-numeric has-spec redirect'>{{t (printf "%v.packages.redirect_to" $baseResource.ToParam) "Redirect To"}} <span>{{$action.RedirectTo}}</span></td>
+                {{else if (eq $type "rewrite")}}
+                  <td class='mdl-data-table__cell--non-numeric has-spec rewrite'>{{t (printf "%v.packages.render_with" $baseResource.ToParam) "Render with"}} <span>{{$action.Template}}</span></td>
+                {{else}}
+                  <td></td>
+                {{end}}
+
+                {{$previewPath := $action.PreviewURL $microSite $context}}
+                {{if $previewPath}}
+                  <td class='mdl-data-table__cell--non-numeric qor-microsite-preview'>
+                    <a target='_blank' href='{{$previewPath}}'>{{t "qor_microsite.template.preview" "PREVIEW"}}</a>
+                  </td>
+                {{else}}
+                  <td class='mdl-data-table__cell--non-numeric qor-microsite-preview--disable'><span>{{t (printf "%v.packages.preview" $baseResource.ToParam) "Preview"}}</span></td>
+                {{end}}
+              </tr>
+            {{end}}
+          </tbody>
+        </table>
+      </div>
+    {{end}}
+
+
+    <div class="qor-file__list">
+      {{if $package.URL}}
+        <a href="{{$package.URL}}" class="qor-file__action-download" title="{{t "qor_media_library.form.download" "Download"}}">
+          {{$package.GetFileName}}
+        </a>
+      {{end}}
+    </div>
+
+    <label class="mdl-button mdl-button--primary qor-button__icon-add" title="{{t "qor_media_library.form.choose_file" "Choose File"}}" {{if not (has_update_permission .Meta)}}disabled{{end}}>
+      <!-- (IE 10+, Edge, Chrome, Firefox 42+) -->
+      <input class="visuallyhidden qor-file__input" id="{{.InputId}}" name="{{.InputName}}" type="file" accept=".zip" />
+
+      {{t (printf "%v.attributes.upload_%v" $baseResource.ToParam (singular (meta_label .Meta))) (printf "Upload %v" (singular (meta_label .Meta)))}}
+    </label>
+  </div>
+</div>

--- a/config/config.go
+++ b/config/config.go
@@ -66,7 +66,7 @@ var (
 	Root           = os.Getenv("GOPATH") + "/src/github.com/qor/qor-example"
 	Mailer         *mailer.Mailer
 	Render         = render.New()
-	AmazonPay      *amazonpay.AmazonPay
+	AmazonPay      amazonpay.AmazonPayService
 	PaymentGateway gomerchant.PaymentGateway
 	RedirectBack   = redirect_back.New(&redirect_back.Config{
 		SessionManager:  manager.SessionManager,


### PR DESCRIPTION
1: disable s3 microsite: 
Have to rewrite `microsite_template_package.tmpl` in qor-example, cause s3 bucket section was written as hard cord in that template.
review at here: https://dev.demo.getqor.com/admin/micro_sites


2: change amazonpay.AmazonPay to amazonpay.AmazonPayService;  
refer new version of `github.com/qor/amazon-pay-sdk-go` https://github.com/qor/amazon-pay-sdk-go/blob/master/amazonpay.go#L63